### PR TITLE
ensure no duplicate repositories when the same repo is in multiple teams

### DIFF
--- a/src/scripts/code-review-karma-report.js
+++ b/src/scripts/code-review-karma-report.js
@@ -191,7 +191,8 @@ async function main() {
         },
       );
     }))
-  ).map(repository => repository.name);
+  ).map(repository => repository.name)
+    .filter(uniqueFilter);
 
   const delayPromises = [];
 


### PR DESCRIPTION
- previously pull requests could be counted twice if the same repository if associated with multiple teams